### PR TITLE
Convert wayward tabs to spaces and more trivial stuff

### DIFF
--- a/ION.lhs
+++ b/ION.lhs
@@ -114,7 +114,7 @@ it with `IK`.
 
 == The numbers game ==
 
-For primitve functions, we use a trick described in depth by Naylor and
+For primitive functions, we use a trick described in depth by Naylor and
 Runciman, "The Reduceron reconfigured and re-evaluated": we introduce a
 combinator called `#` and reduce, say, `# 42 f` to `f(# 42)` for any `f`.
 For example, the term `(I#2)(K(#3)S)(+))` reduces to `(+)(#3)(#2)`.

--- a/atp.lhs
+++ b/atp.lhs
@@ -169,7 +169,7 @@ antecedent proposition starts off in the active list. Then:
   to the head of the list, then move the head to the passive list.
   Pfenning calls these cases 'left asynchronous'.
 
-	3. The active list is empty and we must choose a non-invertible rule.
+  3. The active list is empty and we must choose a non-invertible rule.
   We branch on each such rule. We can apply standard strategies such as
   breadth-first search, depth-first search, or iterative deepening. Pfenning
   calls these cases 'synchronous'.

--- a/vm.c
+++ b/vm.c
@@ -96,7 +96,7 @@ void loadRaw(u (*get)()) {
   hp = 128 - 1;
   for (;;) {
     u c;
-		do c = get(); while (c && (c < '0' || c > '9'));
+    do c = get(); while (c && (c < '0' || c > '9'));
     if (!c) break;
     u n = 0;
     for (;;) {
@@ -476,8 +476,8 @@ void runTests() {
 
 FILE *fp;
 void fp_reset(char *f) {
-	fp = fopen(f, "r");
-	if (!fp) die("fopen failed");
+  fp = fopen(f, "r");
+  if (!fp) die("fopen failed");
 }
 u fp_get() {
   u c = fgetc(fp);
@@ -550,7 +550,7 @@ void rpg() {
 
 void dis(char *file) {
   fp_reset("raw");
-	loadRaw(fp_get);
+  loadRaw(fp_get);
   fp_reset("disassembly.hs");
   buf_reset();
   run(fp_get, buf_put);
@@ -562,7 +562,7 @@ void dis(char *file) {
 
 void runFile(char *f) {
   fp_reset("raw");
-	loadRaw(fp_get);
+  loadRaw(fp_get);
   fp_reset(f);
   buf_reset();
   run(fp_get, buf_put);
@@ -573,7 +573,7 @@ void runFile(char *f) {
 
 void ioccc(char *f) {
   fp_reset("raw");
-	loadRaw(fp_get);
+  loadRaw(fp_get);
   ioccc_reset(f);
   buf_reset();
   run(ioccc_get, buf_put);
@@ -584,7 +584,7 @@ void ioccc(char *f) {
 
 void iotest() {
   fp_reset("raw");
-	loadRaw(fp_get);
+  loadRaw(fp_get);
   str =
     "ioBind2 m k = ioBind m (\\_ -> k);"
     "flst xs n c = case xs of { [] -> n; (:) h t -> c h t };"
@@ -638,9 +638,9 @@ int main(int argc, char **argv) {
       run(ioget, pc);
       return 0;
     }
-		return puts("bad command"), 0;
-	}
-	rpg();
+    return puts("bad command"), 0;
+  }
+  rpg();
   puts(buf);
   return 0;
 }

--- a/vm.c
+++ b/vm.c
@@ -12,7 +12,7 @@ enum { TOP = 1<<23, TABMAX = 1<<10, BUFMAX = 1<<20 };
 //enum { TOP = 1000000, TABMAX = 1<<10, BUFMAX = 1<<20 };
 u *mem, *altmem, *sp, *spTop, hp, tab[TABMAX], tabn;
 
-void stats() { printf("[HP = %u, stack usage = %ld]\n", hp, spTop - sp); }
+void stats() { printf("[HP = %u, stack usage = %td]\n", hp, spTop - sp); }
 
 static inline u isAddr(u n) { return n>=128; }
 
@@ -190,7 +190,7 @@ void run(u (*get)(), void (*put)(u)) {
       case FORWARD: stats(); die("stray forwarding pointer");
       case '.': {
         clock_t end = clock();
-        fprintf(stderr, "gcs = %u, time = %lfms, HP = %u\n", gccount, (end - start) * 1000 / (double) CLOCKS_PER_SEC, hp);
+        fprintf(stderr, "gcs = %u, time = %lfms, HP = %u\n", gccount, (end - start) * 1000.0 / (double) CLOCKS_PER_SEC, hp);
         return;
       }
       case 'Y': lazy(1, arg(1), sp[1]); break;


### PR DESCRIPTION
The sources seems to assume tabs are two spaces (heresy!); fix by
expanding to spaces.  Left the ones in the Makefile alone as they at
least were consistent.